### PR TITLE
[Refactor] Injecting company data to chart page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,5 @@
 import React, { useEffect } from 'react';
-import {
-  Routes,
-  Route,
-  useLocation,
-  useNavigate,
-  Router,
-} from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
 
 // Components
 import AuthCallbackHandler from './components/Auth/AuthCallbackHandler';
@@ -42,7 +36,7 @@ const App: React.FC = () => {
           }
         />
         <Route
-          path="/order:companyCode"
+          path="/order/:companyCode"
           element={
             <MainLayout>
               <TradingPage />

--- a/src/components/CustomOrderBook.tsx
+++ b/src/components/CustomOrderBook.tsx
@@ -3,11 +3,16 @@ import styled from 'styled-components';
 import { submitOrder } from '../services/orderService';
 import { OrderRequest } from '../types/customerorderbook';
 import eventBus from '../util/eventbus';
+import { CompanySearchResponse } from '../types/CompanySearchResponse';
 
 export type OrderSide = 'BUY' | 'SELL';
 export type PriceType = 'limit' | 'market';
 
-const CustomOrderBook: React.FC = () => {
+interface OrderBookProps {
+  companyData: CompanySearchResponse;
+}
+
+const CustomOrderBook: React.FC<OrderBookProps> = ({ companyData }) => {
   const [side, setSide] = useState<OrderSide>('BUY');
   const [priceType, setPriceType] = useState<PriceType>('limit');
   const [price, setPrice] = useState<string>('');
@@ -51,7 +56,7 @@ const CustomOrderBook: React.FC = () => {
     }
 
     const orderRequest: OrderRequest = {
-      companyCode: '005930',
+      companyCode: companyData.isuSrtCd,
       type: side,
       quantity: parseInt(quantity),
       price: priceType === 'limit' ? parseInt(price) : 0,

--- a/src/components/OrderBook.tsx
+++ b/src/components/OrderBook.tsx
@@ -2,8 +2,13 @@ import React, { useEffect, useState, useRef } from 'react';
 import styled from 'styled-components';
 import WebSocketService from '../services/WebSocketService';
 import { OrderBookData, PriceLevel } from '../types/orderbook';
+import { CompanySearchResponse } from '../types/CompanySearchResponse';
 
-const OrderBook: React.FC = () => {
+interface OrderBookProps {
+  companyData: CompanySearchResponse;
+}
+
+const OrderBook: React.FC<OrderBookProps> = ({ companyData }) => {
   const [orderBook, setOrderBook] = useState<OrderBookData | null>(null);
   const prevOrderBook = useRef<OrderBookData | null>(null);
   const prevPrice = useRef<number | null>(null);
@@ -69,26 +74,34 @@ const OrderBook: React.FC = () => {
 
   useEffect(() => {
     orderBookWS.connect();
-    orderBookWS.subscribe('/topic/orderbook/005930', (data: OrderBookData) => {
-      const currentPrice = calculateCurrentPrice(data);
-      const prevPrice = prevOrderBook.current
-        ? calculateCurrentPrice(prevOrderBook.current)
-        : currentPrice;
 
-      const enrichedData = {
-        ...data,
-        currentPrice: currentPrice ?? 0,
-        prevPrice: prevPrice ?? 0,
-      };
+    // 회사 코드를 props에서 가져옴
+    const companyCode = companyData.isuSrtCd;
 
-      prevOrderBook.current = orderBook;
-      setOrderBook(enrichedData);
-    });
+    orderBookWS.subscribe(
+      `/topic/orderbook/${companyCode}`,
+      (data: OrderBookData) => {
+        const currentPrice = calculateCurrentPrice(data);
+        const prevPrice = prevOrderBook.current
+          ? calculateCurrentPrice(prevOrderBook.current)
+          : currentPrice;
+
+        const enrichedData = {
+          ...data,
+          companyCode: companyCode, // 회사 코드 설정
+          currentPrice: currentPrice ?? 0,
+          prevPrice: prevPrice ?? 0,
+        };
+
+        prevOrderBook.current = orderBook;
+        setOrderBook(enrichedData);
+      }
+    );
 
     return () => {
       orderBookWS.disconnect();
     };
-  }, []);
+  }, [companyData.isuSrtCd]);
 
   if (!orderBook) {
     return <Container>Loading...</Container>;
@@ -98,8 +111,8 @@ const OrderBook: React.FC = () => {
     <Container>
       <Header>
         <CompanyInfo>
-          <CompanyCode>{orderBook.companyCode}</CompanyCode>
-          <CompanyName>삼성전자</CompanyName>
+          <CompanyCode>{companyData.isuSrtCd}</CompanyCode>
+          <CompanyName>{companyData.isuNm}</CompanyName>
         </CompanyInfo>
       </Header>
 

--- a/src/components/RealTimeChart.tsx
+++ b/src/components/RealTimeChart.tsx
@@ -8,9 +8,17 @@ import {
 import styled from 'styled-components';
 import axiosInstance from '../api/AxiosInstance';
 import { useStockWebSocket } from '../services/chartWebSocketService';
-import {CandleDto, ChartData, ChartUpdateData, ChartResponseDto} from '../types/chart';
+import {
+  CandleDto,
+  ChartData,
+  ChartUpdateData,
+  ChartResponseDto,
+} from '../types/chart';
+import { CompanySearchResponse } from '../types/CompanySearchResponse';
 
-const CHART_SYMBOL = '005930'; // 삼성전자
+interface OrderBookProps {
+  companyData: CompanySearchResponse;
+}
 
 // 타임프레임 정의
 const TIME_FRAMES = [
@@ -123,7 +131,8 @@ const createSafeChartData = (rawCandles: any[]): ChartData[] => {
   return result;
 };
 
-const RealTimeChart: React.FC = () => {
+const RealTimeChart: React.FC<OrderBookProps> = ({ companyData }) => {
+  const CHART_SYMBOL = companyData.isuSrtCd;
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const candlestickSeriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
@@ -475,7 +484,7 @@ const RealTimeChart: React.FC = () => {
         debugLog('캔들 업데이트 중 오류 발생', err);
       }
     },
-    [selectedTimeFrame]
+    [selectedTimeFrame, companyData.isuSrtCd]
   );
 
   // 캔들 업데이트 핸들러
@@ -638,7 +647,9 @@ const RealTimeChart: React.FC = () => {
     <ChartContainer>
       <ChartHeader>
         <SymbolInfo>
-          <SymbolName>삼성전자 (005930)</SymbolName>
+          <SymbolName>
+            {companyData.isuNm} ({companyData.isuSrtCd})
+          </SymbolName>
           <Exchange>KOSPI</Exchange>
         </SymbolInfo>
         <TimeFrameSelector>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,21 +1,16 @@
+// SearchBar.tsx
 import React, { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import axiosInstance from '../api/AxiosInstance';
 import { Search as SearchIcon } from '@mui/icons-material';
-
-interface CompanySearchResponse {
-  isuNm: string; // 종목명
-  isuSrtCd: string; // 단축코드
-  isuAbbrv: string; // 종목 약어
-  isuEngNm: string; // 영문 종목명
-  kindStkcertTpNm: string; // 주식종류
-}
+import { CompanySearchResponse } from '../types/CompanySearchResponse';
 
 const SearchBar: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [results, setResults] = useState<CompanySearchResponse[]>([]);
   const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const searchRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
 
@@ -36,17 +31,20 @@ const SearchBar: React.FC = () => {
   useEffect(() => {
     const fetchResults = async () => {
       if (searchTerm.length >= 1) {
+        setIsLoading(true);
         try {
           const response = await axiosInstance.get<CompanySearchResponse[]>(
             `/api/companies/search?query=${searchTerm}`
           );
-          console.log(response.data);
+          console.log('검색 결과:', response.data);
 
           setResults(response.data);
           setIsOpen(true);
         } catch (error) {
           console.error('Error fetching search results:', error);
           setResults([]);
+        } finally {
+          setIsLoading(false);
         }
       } else {
         setResults([]);
@@ -59,9 +57,27 @@ const SearchBar: React.FC = () => {
   }, [searchTerm]);
 
   const handleResultClick = (company: CompanySearchResponse) => {
-    navigate(`/trading/${company.isuSrtCd}`);
+    // 회사 정보를 state로 전달하면서 페이지 이동
+    console.log('선택된 회사 정보:', company);
+
+    // 주문 페이지로 이동하면서 회사 정보 전달
+    navigate(`/order/${company.isuSrtCd}`, {
+      state: { selectedCompany: company },
+    });
+
+    // 홈 페이지로 이동하면서 회사 정보 전달하려면 아래 코드 사용
+    // navigate('/', {
+    //   state: { selectedCompany: company }
+    // });
+
     setIsOpen(false);
     setSearchTerm('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && results.length > 0) {
+      handleResultClick(results[0]); // 첫 번째 검색 결과 선택
+    }
   };
 
   return (
@@ -75,32 +91,44 @@ const SearchBar: React.FC = () => {
           placeholder="종목명을 검색하세요"
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
-          onFocus={() => setIsOpen(true)}
+          onFocus={() => searchTerm.length > 0 && setIsOpen(true)}
+          onKeyDown={handleKeyDown}
         />
+        {searchTerm && (
+          <ClearButton onClick={() => setSearchTerm('')}>✕</ClearButton>
+        )}
       </SearchInputWrapper>
-      {isOpen && results.length > 0 && (
+
+      {isOpen && (
         <ResultsDropdown>
-          {results.map((result) => (
-            <ResultItem
-              key={result.isuSrtCd}
-              onClick={() => handleResultClick(result)}
-            >
-              <StockInfo>
-                <StockNameRow>
-                  <StockName>{result.isuNm}</StockName>
-                  <StockEngName>{result.isuEngNm}</StockEngName>
-                </StockNameRow>
-                <StockMeta>
-                  <StockCode>{result.isuSrtCd}</StockCode>
-                  <MarketType>{result.kindStkcertTpNm}</MarketType>
-                </StockMeta>
-              </StockInfo>
-            </ResultItem>
-          ))}
+          {isLoading ? (
+            <LoadingMessage>검색 중...</LoadingMessage>
+          ) : results.length > 0 ? (
+            results.map((result) => (
+              <ResultItem
+                key={result.isuSrtCd}
+                onClick={() => handleResultClick(result)}
+              >
+                <StockInfo>
+                  <StockNameRow>
+                    <StockName>{result.isuNm}</StockName>
+                    {result.isuEngNm && (
+                      <StockEngName>{result.isuEngNm}</StockEngName>
+                    )}
+                  </StockNameRow>
+                  <StockMeta>
+                    <StockCode>{result.isuSrtCd}</StockCode>
+                    {result.kindStkcertTpNm && (
+                      <MarketType>{result.kindStkcertTpNm}</MarketType>
+                    )}
+                  </StockMeta>
+                </StockInfo>
+              </ResultItem>
+            ))
+          ) : searchTerm ? (
+            <NoResults>검색 결과가 없습니다.</NoResults>
+          ) : null}
         </ResultsDropdown>
-      )}
-      {isOpen && searchTerm && results.length === 0 && (
-        <NoResults>검색 결과가 없습니다.</NoResults>
       )}
     </SearchContainer>
   );
@@ -147,6 +175,23 @@ const SearchInput = styled.input`
   &::placeholder {
     color: #8b95a1;
     font-size: 15px;
+  }
+`;
+
+const ClearButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #8b95a1;
+  font-size: 14px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+
+  &:hover {
+    color: #191f28;
   }
 `;
 
@@ -219,6 +264,13 @@ const MarketType = styled.div`
 `;
 
 const NoResults = styled.div`
+  padding: 16px;
+  text-align: center;
+  font-size: 14px;
+  color: #8b95a1;
+`;
+
+const LoadingMessage = styled.div`
   padding: 16px;
   text-align: center;
   font-size: 14px;

--- a/src/components/TradeHistory.tsx
+++ b/src/components/TradeHistory.tsx
@@ -3,8 +3,13 @@ import styled from 'styled-components';
 import { TradeHistory } from '../types/tradehistory';
 import axiosInstance from '../api/AxiosInstance';
 import eventbus from '../util/eventbus';
+import { CompanySearchResponse } from '../types/CompanySearchResponse';
 
-const TradeHistoryList: React.FC = () => {
+interface OrderBookProps {
+  companyData: CompanySearchResponse;
+}
+
+const TradeHistoryList: React.FC<OrderBookProps> = ({ companyData }) => {
   const [trades, setTrades] = useState<TradeHistory[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/src/pages/Base/TradingPage.tsx
+++ b/src/pages/Base/TradingPage.tsx
@@ -1,36 +1,146 @@
-import React from 'react';
-import styled from 'styled-components';
+// TradingPage.tsx (styled 부분 제외)
+import React, { useEffect, useState } from 'react';
+import { useParams, useLocation } from 'react-router-dom';
 import OrderBook from '../../components/OrderBook';
 import TradeHistoryList from '../../components/TradeHistory';
 import CustomOrderBook from '../../components/CustomOrderBook';
 import RealTimeChart from '../../components/RealTimeChart';
+import axiosInstance from '../../api/AxiosInstance';
+import { CompanySearchResponse } from '../../types/CompanySearchResponse';
+import styled from 'styled-components';
 
 const TradingPage: React.FC = () => {
+  const { companyCode } = useParams<{ companyCode: string }>();
+  const location = useLocation();
+
+  // location.state에서 선택된 회사 정보 가져오기
+  const initialCompany = location.state?.selectedCompany as
+    | CompanySearchResponse
+    | undefined;
+
+  const [company, setCompany] = useState<CompanySearchResponse | null>(
+    initialCompany || null
+  );
+  const [loading, setLoading] = useState<boolean>(!initialCompany);
+
+  useEffect(() => {
+    // 이미 회사 정보가 있고 코드가 일치하면 API 호출 건너뛰기
+    if (initialCompany && initialCompany.isuSrtCd === companyCode) {
+      setCompany(initialCompany);
+      setLoading(false);
+      return;
+    }
+
+    const fetchCompanyInfo = async () => {
+      if (companyCode) {
+        try {
+          setLoading(true);
+          // 회사 코드로 회사 정보 조회
+          const response = await axiosInstance.get<CompanySearchResponse>(
+            `/api/companies/${companyCode}`
+          );
+          setCompany(response.data);
+        } catch (error) {
+          console.error('회사 정보 조회 실패:', error);
+        } finally {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchCompanyInfo();
+  }, [companyCode, initialCompany]);
+
+  if (loading) {
+    return <LoadingContainer>로딩 중...</LoadingContainer>;
+  }
+
+  if (!company) {
+    return <ErrorContainer>회사 정보를 찾을 수 없습니다.</ErrorContainer>;
+  }
+
   return (
     <PageContainer>
+      <CompanyHeader>
+        <CompanyName>{company.isuNm}</CompanyName>
+        <CompanyCode>{company.isuSrtCd}</CompanyCode>
+        <CompanyType>{company.kindStkcertTpNm}</CompanyType>
+      </CompanyHeader>
+
       <ContentGrid>
         <LeftPanel>
           <ChartSection>
-            <RealTimeChart />
+            {/* props 타입이 정의된 컴포넌트 사용 */}
+            <RealTimeChart companyData={company} />
           </ChartSection>
         </LeftPanel>
         <CenterPanel>
           <OrderBookSection>
-            <OrderBook />
+            {/* props 타입이 정의된 컴포넌트 사용 */}
+            <OrderBook companyData={company} />
           </OrderBookSection>
         </CenterPanel>
         <RightPanel>
           <CustomOrderPanel>
-            <CustomOrderBook />
+            {/* props 타입이 정의된 컴포넌트 사용 */}
+            <CustomOrderBook companyData={company} />
           </CustomOrderPanel>
           <TradeHistoryPanel>
-            <TradeHistoryList />
+            {/* props 타입이 정의된 컴포넌트 사용 */}
+            <TradeHistoryList companyData={company} />
           </TradeHistoryPanel>
         </RightPanel>
       </ContentGrid>
     </PageContainer>
   );
 };
+
+const CompanyHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 24px 16px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid #eaedf0;
+`;
+
+const CompanyName = styled.h1`
+  font-size: 24px;
+  font-weight: 600;
+  color: #191f28;
+  margin: 0;
+`;
+
+const CompanyCode = styled.span`
+  font-size: 16px;
+  color: #8b95a1;
+  padding: 4px 8px;
+  background: #f2f4f6;
+  border-radius: 6px;
+`;
+
+const CompanyType = styled.span`
+  font-size: 14px;
+  color: #8b95a1;
+`;
+
+const LoadingContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  font-size: 18px;
+  color: #8b95a1;
+`;
+
+const ErrorContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  font-size: 18px;
+  color: #e63946;
+`;
 
 const PageContainer = styled.div`
   min-height: 100vh;
@@ -111,6 +221,7 @@ const CustomOrderPanel = styled.div`
   display: flex;
   flex-direction: column;
 `;
+
 const TradeHistoryPanel = styled.div`
   background: white;
   border-radius: 16px;

--- a/src/types/CompanySearchResponse.ts
+++ b/src/types/CompanySearchResponse.ts
@@ -1,0 +1,7 @@
+export interface CompanySearchResponse {
+  isuNm: string; // 종목명
+  isuSrtCd: string; // 단축코드
+  isuAbbrv: string; // 종목 약어
+  isuEngNm: string; // 영문 종목명
+  kindStkcertTpNm: string; // 주식종류
+}


### PR DESCRIPTION
### 💡 I resolved the following issues:

- When user searches company and click to move that trading page, that page really handle that searched company's data.

<br><br>

### 💡 Code has been added while handling the issue:

- [refactor : Injecting company data to chart page](https://github.com/Stocks-Are-Everywhere/frontend/pull/35/commits/7582f98bb739162999a29a38df07c7567341ff20)

<br><br>

### 💡 Follow-up tasks are needed:

- Trading history could be changed for real trading history. this version shows dummy data.

<br><br>

### 💡 The following resources might be helpful:

- (Remove this section if not applicable.)

<br><br>

### ✅ Self Checklist

- [x] I am submitting this PR to the correct branch according to our branching strategy. (Not to master/main)

- [x] My commit messages follow the convention.

- [x] The modified code does not generate any compiler/browser warnings/errors.

- [x] The modified code passes all existing tests.

- [x] I have reviewed whether test additions are necessary and added them if needed.

- [x] I have reviewed whether documentation updates are necessary and updated them if needed.
